### PR TITLE
Travis: install covr only if COVERAGE = true

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - ./pkg-build.sh bootstrap
 
 install:
-  - ./pkg-build.sh install_github jimhester/covr
+  - if [[ ! -z "$COVERAGE" ]];then ./pkg-build.sh install_github jimhester/covr; fi
   - ./pkg-build.sh install_deps
 
 script:


### PR DESCRIPTION
This will prevent travis tests from failing with R oldrel like, for example, when it failed here: https://travis-ci.org/renkun-ken/formattable/jobs/102054878