### PR TITLE
add bootstrap table class for knit when format is html

### DIFF
--- a/R/formattable.R
+++ b/R/formattable.R
@@ -487,7 +487,14 @@ format_table <- function(x, formatters = list(),
       mat[row, col] <- format(fv)
     }
   }
-  kable(mat, format = format, align = align, escape = FALSE, ...)
+
+  # add class for bootstrap styling if html format
+  table_attr <- NULL
+  if (format=="html") {
+    table_attr = 'class="table table-condensed"'
+  }
+  kable(mat, format = format, align = align, escape = FALSE,
+        table.attr = table_attr, ...)
 }
 
 #' Create a formattable data frame


### PR DESCRIPTION
Due to the change in `v0.2` for default format `html`, when using in `knitr` or `rmarkdown`, we lose the table styling.  This pull adds bootstrap class `table table-condensed` to get the bootstrap styling back.  To try, render the demo `rmd`.