### PR TITLE
Set up GitHub Pages

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,6 @@
 ^CRAN-RELEASE$
 ^cran-comments\.md$
 ^\.vscode$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,73 @@
+on:
+  push:
+    branches:
+    - master
+    - docs
+    - "cran-*"
+
+name: pkgdown
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-18.04
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@master
+
+      - uses: r-lib/actions/setup-pandoc@master
+
+      - name: Query dependencies
+        run: |
+          install.packages("remotes")
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Configure Git identity
+        run: |
+          env | sort
+          git config --global user.name "$GITHUB_WORKFLOW"
+          git config --global user.email "${GITHUB_EVENT_NAME}@ghactions.local"
+        shell: bash
+
+      - name: Install system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          while read -r cmd
+          do
+            eval sudo $cmd
+          done < <(Rscript -e 'req <- remotes::system_requirements("ubuntu", "18.04"); if (length(req) > 0) cat(req, sep = "\n")')
+
+      - name: Install pkgdown sysdeps
+        if: runner.os == 'Linux'
+        env:
+          RHUB_PLATFORM: linux-x86_64-ubuntu-gcc
+        run: |
+          sudo apt-get install -y libharfbuzz-dev libfribidi-dev
+
+      - name: Install dependencies
+        run: |
+          install.packages("remotes")
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_github("krlmlr/pkgdown@fix/examples-dontshow")
+        shell: Rscript {0}
+
+      - name: Install package
+        run: R CMD INSTALL .
+
+      - name: Deploy package
+        run: |
+          pkgdown::deploy_to_branch(new_process = FALSE)
+        shell: Rscript {0}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /README.html
 inst/doc
 .vscode/
+docs

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,47 @@
+reference:
+- title: Number formats
+  contents:
+  - accounting
+  - comma
+  - currency
+  - digits
+  - percent
+  - prefix
+  - scientific
+  - suffix
+
+- title: Other functions
+  contents:
+  - area
+  - as.datatable
+  - as.datatable.formattable
+  - as.htmlwidget
+  - as.htmlwidget.formattable
+  - color_bar
+  - color_text
+  - color_tile
+  - csscolor
+  - format_table
+  - '`formattable-package`'
+  - formattable
+  - formattable.Date
+  - formattable.POSIXct
+  - formattable.POSIXlt
+  - formattable.data.frame
+  - formattable.default
+  - formattable.factor
+  - formattable.logical
+  - formattable.numeric
+  - formattableOutput
+  - formatter
+  - gradient
+  - icontext
+  - is.formattable
+  - normalize
+  - normalize_bar
+  - proportion
+  - proportion_bar
+  - qrank
+  - renderFormattable
+  - style
+  - vmap


### PR DESCRIPTION
with a reference index that distinguishes between vector functions and everything else.

To preview, run `pkgdown::build_site()` locally.

To switch, you need to run `git push origin :gh-pages` to erase the old webpage. If you want to keep a backup:

```
git worktree add website gh-pages
cd website
git branch -m website
git push -u origin HEAD
# switch GitHub Pages to serve website branch (possible now)
git push origin :gh-pages
# switch GitHub Pages to serve gh-pages branch
```

I'm not sure contributor access will help here, I can't seem to do these actions as a contributor.