### PR TITLE
fun = "proportion" => fun = proportion

### DIFF
--- a/R/formatter.R
+++ b/R/formatter.R
@@ -139,7 +139,7 @@ color_tile <- function(...) {
 #' formattable(mtcars, list(mpg = color_bar("lightgray", proportion)))
 #' @seealso
 #' [normalize_bar()], [proportion_bar()]
-color_bar <- function(color = "lightgray", fun = "proportion", ...) {
+color_bar <- function(color = "lightgray", fun = proportion, ...) {
   fun <- match.fun(fun)
   formatter("span",
     style = function(x) style(

--- a/man/color_bar.Rd
+++ b/man/color_bar.Rd
@@ -4,7 +4,7 @@
 \alias{color_bar}
 \title{Create a color-bar formatter}
 \usage{
-color_bar(color = "lightgray", fun = "proportion", ...)
+color_bar(color = "lightgray", fun = proportion, ...)
 }
 \arguments{
 \item{color}{the background color of the bars}


### PR DESCRIPTION
The default value of `fun` of `color_bar()`  should be changed to the function `proportion`, rather than a string "proportion", so that `color_bar()` can work without attaching the package formattable.

---

**in a clean session without the `formattable` package attached**

### Before the Patch 

``` r
formattable::formattable(
  head(iris),
  list(Sepal.Length = formattable::color_bar())
)
#> Error in get(as.character(FUN), mode = "function", envir = envir): object 'proportion' of mode 'function' was not found
```

<sup>Created on 2021-11-30 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

### After the Patch

``` r
formattable::formattable(
  head(iris),
  list(Sepal.Length = formattable::color_bar())
)
```

<table class="table table-condensed">
<thead>
<tr>
<th style="text-align:right;">
Sepal.Length
</th>
<th style="text-align:right;">
Sepal.Width
</th>
<th style="text-align:right;">
Petal.Length
</th>
<th style="text-align:right;">
Petal.Width
</th>
<th style="text-align:right;">
Species
</th>
</tr>
</thead>
<tbody>
<tr>
<td style="text-align:right;">
<span style="display: inline-block; direction: rtl; unicode-bidi: plaintext; border-radius: 4px; padding-right: 2px; background-color: lightgray; width: 94.44%">5.1</span>
</td>
<td style="text-align:right;">
3.5
</td>
<td style="text-align:right;">
1.4
</td>
<td style="text-align:right;">
0.2
</td>
<td style="text-align:right;">
setosa
</td>
</tr>
<tr>
<td style="text-align:right;">
<span style="display: inline-block; direction: rtl; unicode-bidi: plaintext; border-radius: 4px; padding-right: 2px; background-color: lightgray; width: 90.74%">4.9</span>
</td>
<td style="text-align:right;">
3.0
</td>
<td style="text-align:right;">
1.4
</td>
<td style="text-align:right;">
0.2
</td>
<td style="text-align:right;">
setosa
</td>
</tr>
<tr>
<td style="text-align:right;">
<span style="display: inline-block; direction: rtl; unicode-bidi: plaintext; border-radius: 4px; padding-right: 2px; background-color: lightgray; width: 87.04%">4.7</span>
</td>
<td style="text-align:right;">
3.2
</td>
<td style="text-align:right;">
1.3
</td>
<td style="text-align:right;">
0.2
</td>
<td style="text-align:right;">
setosa
</td>
</tr>
<tr>
<td style="text-align:right;">
<span style="display: inline-block; direction: rtl; unicode-bidi: plaintext; border-radius: 4px; padding-right: 2px; background-color: lightgray; width: 85.19%">4.6</span>
</td>
<td style="text-align:right;">
3.1
</td>
<td style="text-align:right;">
1.5
</td>
<td style="text-align:right;">
0.2
</td>
<td style="text-align:right;">
setosa
</td>
</tr>
<tr>
<td style="text-align:right;">
<span style="display: inline-block; direction: rtl; unicode-bidi: plaintext; border-radius: 4px; padding-right: 2px; background-color: lightgray; width: 92.59%">5.0</span>
</td>
<td style="text-align:right;">
3.6
</td>
<td style="text-align:right;">
1.4
</td>
<td style="text-align:right;">
0.2
</td>
<td style="text-align:right;">
setosa
</td>
</tr>
<tr>
<td style="text-align:right;">
<span style="display: inline-block; direction: rtl; unicode-bidi: plaintext; border-radius: 4px; padding-right: 2px; background-color: lightgray; width: 100.00%">5.4</span>
</td>
<td style="text-align:right;">
3.9
</td>
<td style="text-align:right;">
1.7
</td>
<td style="text-align:right;">
0.4
</td>
<td style="text-align:right;">
setosa
</td>
</tr>
</tbody>
</table>

<sup>Created on 2021-11-30 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>